### PR TITLE
chore: replace GitHub dependabot reviewers with codeowners (INTERN-68)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub Actions files
+/.github/               @skriptfabrik/github-actions-maintainers
+
+# Devcontainer configuration
+/.devcontainer/         @skriptfabrik/devcontainer-maintainers

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,13 +5,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - skriptfabrik/github-actions-maintainers
 
   - package-ecosystem: 'devcontainers'
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - skriptfabrik/devcontainer-maintainers
-    
+


### PR DESCRIPTION
This pull request will replace the retiring dependabot reviewers configuration with CODEOWNERS.